### PR TITLE
chore: `kona` `0.1.0-beta.16`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2979,7 +2979,7 @@ dependencies = [
 [[package]]
 name = "kona-cli"
 version = "0.2.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "clap",
  "libc",
@@ -2991,7 +2991,7 @@ dependencies = [
 [[package]]
 name = "kona-client"
 version = "0.1.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3027,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "kona-derive"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3047,7 +3047,7 @@ dependencies = [
 [[package]]
 name = "kona-driver"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3068,7 +3068,7 @@ dependencies = [
 [[package]]
 name = "kona-executor"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3087,7 +3087,7 @@ dependencies = [
 [[package]]
 name = "kona-genesis"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3104,7 +3104,7 @@ dependencies = [
 [[package]]
 name = "kona-hardforks"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -3114,7 +3114,7 @@ dependencies = [
 [[package]]
 name = "kona-host"
 version = "0.1.1"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "kona-interop"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3181,7 +3181,7 @@ dependencies = [
 [[package]]
 name = "kona-mpt"
 version = "0.2.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -3193,7 +3193,7 @@ dependencies = [
 [[package]]
 name = "kona-preimage"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "alloy-primitives",
  "async-channel",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "kona-proof"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3236,7 +3236,7 @@ dependencies = [
 [[package]]
 name = "kona-proof-interop"
 version = "0.2.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3263,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "kona-protocol"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
@@ -3289,7 +3289,7 @@ dependencies = [
 [[package]]
 name = "kona-providers-alloy"
 version = "0.2.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3314,7 +3314,7 @@ dependencies = [
 [[package]]
 name = "kona-registry"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -3328,7 +3328,7 @@ dependencies = [
 [[package]]
 name = "kona-rpc"
 version = "0.2.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -3341,7 +3341,7 @@ dependencies = [
 [[package]]
 name = "kona-serde"
 version = "0.2.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -3351,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "kona-std-fpvm"
 version = "0.2.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -3364,7 +3364,7 @@ dependencies = [
 [[package]]
 name = "kona-std-fpvm-proc"
 version = "0.2.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.15#1d4c2fca60b75e2418239358e86b9e2e09b1035d"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv0.1.0-beta.16#d8dbf5156edc0acf9646c1b002eda62be7228bae"
 dependencies = [
  "cfg-if",
  "kona-std-fpvm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ members = ["bin/*", "crates/*"]
 # Workspace
 hana-client = { path = "bin/client", version = "0.1.0", default-features = false }
 hana-celestia = { path = "crates/celestia", version = "0.1.0", default-features = false }
-hana-proofs = { path = "crates/proofs", version = "0.1.0", default-features = false}
-hana-blobstream = { path = "crates/blobstream", version = "0.1.0", default-features = false}
+hana-proofs = { path = "crates/proofs", version = "0.1.0", default-features = false }
+hana-blobstream = { path = "crates/blobstream", version = "0.1.0", default-features = false }
 hana-oracle = { path = "crates/oracle", version = "0.1.0", default-features = false }
 
 # Kona
@@ -15,21 +15,21 @@ hana-oracle = { path = "crates/oracle", version = "0.1.0", default-features = fa
 # but publish infrequently (last was 2 weeks ago). We want to make sure to use the latest code
 # while we're still figuring out how to integrate with it.
 # Replace these version-based dependencies
-kona-mpt = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.15", default-features = false }
-kona-derive = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.15", default-features = false }
-kona-driver = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.15", default-features = false }
-kona-executor = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.15", default-features = false }
-kona-proof = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.15", default-features = false }
-kona-std-fpvm = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.15", default-features = false }
-kona-preimage = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.15", default-features = false }
-kona-std-fpvm-proc = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.15", default-features = false }
-kona-providers-alloy = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.15", default-features = false }
-kona-protocol = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.15", default-features = false }
-kona-genesis = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.15", default-features = false }
-kona-rpc = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.15", default-features = false }
-kona-client = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.15", default-features = false }
-kona-host = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.15" }
-kona-cli = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.15" }
+kona-mpt = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16", default-features = false }
+kona-derive = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16", default-features = false }
+kona-driver = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16", default-features = false }
+kona-executor = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16", default-features = false }
+kona-proof = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16", default-features = false }
+kona-std-fpvm = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16", default-features = false }
+kona-preimage = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16", default-features = false }
+kona-std-fpvm-proc = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16", default-features = false }
+kona-providers-alloy = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16", default-features = false }
+kona-protocol = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16", default-features = false }
+kona-genesis = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16", default-features = false }
+kona-rpc = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16", default-features = false }
+kona-client = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16", default-features = false }
+kona-host = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16" }
+kona-cli = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.16" }
 
 # Alloy
 alloy-rlp = { version = "^0.3.11", default-features = false }
@@ -96,8 +96,8 @@ unsigned-varint = "0.8.0"
 revm = { version = "16.0.0", default-features = false }
 
 # Celestia
-celestia-types = {git = "https://github.com/eigerco/lumina", rev = "4751731" }
-celestia-rpc = {git = "https://github.com/eigerco/lumina", rev = "4751731" }
+celestia-types = { git = "https://github.com/eigerco/lumina", rev = "4751731" }
+celestia-rpc = { git = "https://github.com/eigerco/lumina", rev = "4751731" }
 jsonrpsee = "0.24.9"
 
 [profile.dev]


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Bump `kona` version to https://github.com/op-rs/kona/releases/tag/kona-client%2Fv0.1.0-beta.16 for Sepolia/Mainnet Isthmus compatibility.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
