### PR TITLE
account proof verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2648,6 +2648,7 @@ name = "hana-oracle"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-rpc-types-eth",
  "async-trait",
  "bincode",
  "celestia-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2676,7 +2676,6 @@ dependencies = [
  "celestia-rpc",
  "celestia-types",
  "hana-blobstream",
- "serde_json",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2570,6 +2570,7 @@ dependencies = [
  "alloy-contract",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types-eth",
  "alloy-sol-types",
  "alloy-trie",
  "bincode",

--- a/bin/host/src/celestia/handler.rs
+++ b/bin/host/src/celestia/handler.rs
@@ -89,8 +89,11 @@ impl HintHandler for CelestiaChainHintHandler {
                     blobstream_proof.storage_root,
                     blobstream_proof.storage_proof,
                     blobstream_proof.account_proof,
-                    blobstream_proof.l1_head,
+                    blobstream_proof.state_root,
                     blobstream_proof.blobstream_address,
+                    blobstream_proof.blobstream_balance,
+                    blobstream_proof.blobstream_nonce,
+                    blobstream_proof.blobstream_code_hash,
                 )
                 .to_bytes()
                 .expect("failed to serialize celestia oracle payload");

--- a/bin/host/src/celestia/handler.rs
+++ b/bin/host/src/celestia/handler.rs
@@ -79,6 +79,17 @@ impl HintHandler for CelestiaChainHintHandler {
                 )
                 .await?;
 
+                let mut header = blobstream_proof.block_header.clone();
+
+                header.state_root = blobstream_proof.state_root;
+
+                let block_hash = header.hash_slow();
+
+                assert!(
+                    block_hash == cfg.single_host.l1_head,
+                    "computed block hash must match host l1 head"
+                );
+
                 let payload = OraclePayload::new(
                     Bytes::from(data),
                     blobstream_proof.data_root,

--- a/bin/host/src/celestia/handler.rs
+++ b/bin/host/src/celestia/handler.rs
@@ -79,17 +79,6 @@ impl HintHandler for CelestiaChainHintHandler {
                 )
                 .await?;
 
-                let mut header = blobstream_proof.block_header.clone();
-
-                header.state_root = blobstream_proof.state_root;
-
-                let block_hash = header.hash_slow();
-
-                assert!(
-                    block_hash == cfg.single_host.l1_head,
-                    "computed block hash must match host l1 head"
-                );
-
                 let payload = OraclePayload::new(
                     Bytes::from(data),
                     blobstream_proof.data_root,
@@ -105,6 +94,8 @@ impl HintHandler for CelestiaChainHintHandler {
                     blobstream_proof.blobstream_balance,
                     blobstream_proof.blobstream_nonce,
                     blobstream_proof.blobstream_code_hash,
+                    blobstream_proof.block_header,
+                    cfg.single_host.l1_head,
                 )
                 .to_bytes()
                 .expect("failed to serialize celestia oracle payload");

--- a/crates/blobstream/Cargo.toml
+++ b/crates/blobstream/Cargo.toml
@@ -11,6 +11,7 @@ alloy-sol-types.workspace = true
 alloy-trie.workspace = true
 alloy-contract.workspace = true
 alloy-rlp.workspace = true
+alloy-rpc-types-eth.workspace = true
 
 bincode.workspace = true
 celestia-types.workspace = true

--- a/crates/blobstream/src/blobstream.rs
+++ b/crates/blobstream/src/blobstream.rs
@@ -1,7 +1,7 @@
 use std::boxed::Box;
 
 use alloc::vec::Vec;
-use alloy_primitives::{keccak256, Address, Bytes, FixedBytes, B256, U256};
+use alloy_primitives::{aliases::B224, keccak256, Address, Bytes, FixedBytes, B256, U256};
 use alloy_rpc_types_eth::Header;
 use alloy_sol_types::sol;
 use alloy_trie::{
@@ -168,7 +168,19 @@ pub fn verify_data_commitment_storage(
     blobstream_balance: U256,
     blobstream_nonce: u64,
     blobstream_code_hash: B256,
+    block_header: Header,
+    l1_block_hash: B256,
 ) -> Result<(), ProofVerificationError> {
+    let mut header = block_header.clone();
+
+    header.state_root = state_root;
+
+    let block_hash = header.hash_slow();
+
+    assert!(
+        block_hash == l1_block_hash,
+        "computed block hash must match host l1 head"
+    );
     // Currently verifies the value of the slot
     // need to verify the storage root agains the state root of the block
     // Calculate the storage slot for state_dataCommitments[nonce]

--- a/crates/blobstream/src/blobstream.rs
+++ b/crates/blobstream/src/blobstream.rs
@@ -2,6 +2,7 @@ use std::boxed::Box;
 
 use alloc::vec::Vec;
 use alloy_primitives::{keccak256, Address, Bytes, FixedBytes, B256, U256};
+use alloy_rpc_types_eth::Header;
 use alloy_sol_types::sol;
 use alloy_trie::{
     proof::{verify_proof, ProofVerificationError},
@@ -83,6 +84,8 @@ pub struct BlobstreamProof {
     pub blobstream_nonce: u64,
     /// The code hash to verify against the blobstream address
     pub blobstream_code_hash: B256,
+    /// The block header to verify against the l1 head
+    pub block_header: Header,
 }
 
 impl BlobstreamProof {
@@ -101,6 +104,7 @@ impl BlobstreamProof {
         blobstream_balance: U256,
         blobstream_nonce: u64,
         blobstream_code_hash: B256,
+        block_header: Header,
     ) -> Self {
         Self {
             data_root,
@@ -116,6 +120,7 @@ impl BlobstreamProof {
             blobstream_balance,
             blobstream_nonce,
             blobstream_code_hash,
+            block_header,
         }
     }
 

--- a/crates/oracle/Cargo.toml
+++ b/crates/oracle/Cargo.toml
@@ -17,6 +17,7 @@ hana-celestia.workspace = true
 hana-blobstream.workspace = true
 
 alloy-primitives.workspace = true
+alloy-rpc-types-eth.workspace = true
 
 spin.workspace = true
 

--- a/crates/oracle/src/payload.rs
+++ b/crates/oracle/src/payload.rs
@@ -24,10 +24,16 @@ pub struct OraclePayload {
     pub storage_proof: Vec<Bytes>,
     /// The account proof for the blobstream address
     pub account_proof: Vec<Bytes>,
-    /// The L1 head hash to verify the account proof against
-    pub l1_head: FixedBytes<32>,
+    /// The L1 state root hash to verify the account proof against
+    pub state_root: FixedBytes<32>,
     /// The blobstream address to verify
     pub blobstream_address: Address,
+    /// The balance to verify against the blobstream address
+    pub blobstream_balance: U256,
+    /// The nonce to verify against the blobstream address
+    pub blobstream_nonce: u64,
+    /// The code hash to verify against the blobstream address
+    pub blobstream_code_hash: B256,
 }
 
 impl OraclePayload {
@@ -42,8 +48,11 @@ impl OraclePayload {
         storage_root: B256,
         storage_proof: Vec<Bytes>,
         account_proof: Vec<Bytes>,
-        l1_head: FixedBytes<32>,
+        state_root: FixedBytes<32>,
         blobstream_address: Address,
+        blobstream_balance: U256,
+        blobstream_nonce: u64,
+        blobstream_code_hash: B256,
     ) -> Self {
         Self {
             blob,
@@ -55,8 +64,11 @@ impl OraclePayload {
             storage_root,
             storage_proof,
             account_proof,
-            l1_head,
+            state_root,
             blobstream_address,
+            blobstream_balance,
+            blobstream_nonce,
+            blobstream_code_hash,
         }
     }
 

--- a/crates/oracle/src/payload.rs
+++ b/crates/oracle/src/payload.rs
@@ -1,5 +1,6 @@
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{Address, Bytes, FixedBytes, B256, U256};
+use alloy_rpc_types_eth::Header;
 use celestia_types::{hash::Hash, MerkleProof, ShareProof};
 use serde::{Deserialize, Serialize};
 
@@ -34,6 +35,10 @@ pub struct OraclePayload {
     pub blobstream_nonce: u64,
     /// The code hash to verify against the blobstream address
     pub blobstream_code_hash: B256,
+    /// The block header to verify against the l1 head
+    pub block_header: Header,
+    /// The storage root to verify against
+    pub l1_block_hash: B256,
 }
 
 impl OraclePayload {
@@ -53,6 +58,8 @@ impl OraclePayload {
         blobstream_balance: U256,
         blobstream_nonce: u64,
         blobstream_code_hash: B256,
+        block_header: Header,
+        l1_block_hash: B256,
     ) -> Self {
         Self {
             blob,
@@ -69,6 +76,8 @@ impl OraclePayload {
             blobstream_balance,
             blobstream_nonce,
             blobstream_code_hash,
+            block_header,
+            l1_block_hash,
         }
     }
 

--- a/crates/oracle/src/provider.rs
+++ b/crates/oracle/src/provider.rs
@@ -82,6 +82,8 @@ impl<T: CommsClient + Sync + Send> CelestiaProvider for OracleCelestiaProvider<T
             payload.blobstream_balance,
             payload.blobstream_nonce,
             payload.blobstream_code_hash,
+            payload.block_header,
+            payload.l1_block_hash,
         )
         .expect("Failed to verify data commitment against Blobstream storage slot");
 

--- a/crates/oracle/src/provider.rs
+++ b/crates/oracle/src/provider.rs
@@ -73,12 +73,15 @@ impl<T: CommsClient + Sync + Send> CelestiaProvider for OracleCelestiaProvider<T
 
         verify_data_commitment_storage(
             payload.storage_root,
-            payload.l1_head,
+            payload.state_root,
             payload.storage_proof,
             payload.account_proof,
             payload.proof_nonce,
             payload.data_commitment,
             payload.blobstream_address,
+            payload.blobstream_balance,
+            payload.blobstream_nonce,
+            payload.blobstream_code_hash,
         )
         .expect("Failed to verify data commitment against Blobstream storage slot");
 

--- a/crates/proofs/Cargo.toml
+++ b/crates/proofs/Cargo.toml
@@ -16,4 +16,3 @@ tracing.workspace = true
 celestia-types.workspace = true
 celestia-rpc.workspace = true
 anyhow.workspace = true
-serde_json.workspace = true

--- a/crates/proofs/src/blobstream_inclusion.rs
+++ b/crates/proofs/src/blobstream_inclusion.rs
@@ -111,6 +111,8 @@ pub async fn get_blobstream_proof(
     let block_id = BlockId::Hash(RpcBlockHash::from(B256::from(l1_head)));
 
     let state_root = l1_block.header.state_root;
+
+    let block_header = l1_block.header;
     // Fetch the block's data root
     let header = celestia_node.header_get_by_height(height).await?;
 
@@ -217,6 +219,7 @@ pub async fn get_blobstream_proof(
                 blobstream_balance,
                 blobstream_nonce,
                 blobstream_code_hash,
+                block_header,
             ));
         }
         Err(err) => anyhow::bail!("Error verifying storage proof {}", err),

--- a/crates/proofs/src/blobstream_inclusion.rs
+++ b/crates/proofs/src/blobstream_inclusion.rs
@@ -2,7 +2,7 @@ use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{keccak256, Address, Bytes, FixedBytes, B256};
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types_eth::{
-    BlockId, BlockNumberOrTag, Filter, FilterBlockOption, FilterSet, RpcBlockHash,
+    BlockId, BlockNumberOrTag, Filter, FilterBlockOption, FilterSet, Header, RpcBlockHash,
 };
 use alloy_sol_types::SolEvent;
 use celestia_rpc::{blobstream::BlobstreamClient, Client, HeaderClient, ShareClient};
@@ -201,6 +201,8 @@ pub async fn get_blobstream_proof(
         blobstream_balance,
         blobstream_nonce,
         blobstream_code_hash,
+        block_header.clone(),
+        l1_head,
     ) {
         Ok(_) => {
             println!("Succesfully verified storage proof for Blobstream data commitment");


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Adds account proof verification and specifies the `l1Head` as the l1 height to be used for storage proofs when verifying against Blobstream.

Tackles problem (2) from #11
