### PR TITLE
fix: fix storage proof verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,6 +2574,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "alloy-trie",
+ "anyhow",
  "bincode",
  "celestia-types",
  "serde",

--- a/bin/client/justfile
+++ b/bin/client/justfile
@@ -41,7 +41,8 @@ run-client-native block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc celes
   cd $(git rev-parse --show-toplevel)
 
   echo "Running host program with native client program..."
-  RUST_LOG=trace cargo r --bin hana-host --release -- \
+  cargo r --bin hana-host --release -- \
+    {{verbosity}} \
     celestia \
     --l1-head $L1_HEAD \
     --agreed-l2-head-hash $AGREED_L2_HEAD_HASH \
@@ -55,8 +56,7 @@ run-client-native block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc celes
     --celestia-namespace $NAMESPACE \
     --native \
     --data-dir ./data \
-    $CHAIN_ID_OR_ROLLUP_CONFIG_ARG \
-    {{verbosity}}
+    $CHAIN_ID_OR_ROLLUP_CONFIG_ARG
 
 # Run the client program natively with the host program attached, in offline mode.
 run-client-native-offline block_number l2_claim l2_output_root l2_head l1_head l2_chain_id verbosity='':

--- a/crates/blobstream/Cargo.toml
+++ b/crates/blobstream/Cargo.toml
@@ -14,6 +14,7 @@ alloy-rlp.workspace = true
 alloy-chains.workspace = true
 alloy-rpc-types-eth.workspace = true
 
+anyhow.workspace = true
 bincode.workspace = true
 celestia-types.workspace = true
 serde.workspace = true

--- a/crates/oracle/src/provider.rs
+++ b/crates/oracle/src/provider.rs
@@ -6,7 +6,7 @@ use alloy_primitives::{keccak256, Bytes};
 use async_trait::async_trait;
 use celestia_types::Commitment;
 use hana_blobstream::blobstream::{
-    blostream_address, encode_data_root_tuple, verify_data_commitment_storage,
+    blostream_address, encode_data_root_tuple, verify_data_commitment,
 };
 use hana_celestia::CelestiaProvider;
 use kona_preimage::errors::PreimageOracleError;
@@ -66,7 +66,7 @@ impl<T: CommsClient + Sync + Send> CelestiaProvider for OracleCelestiaProvider<T
             .expect("No canonical Blobstream address found for chain id");
 
         // Verify the data commitment exists in storage on the supplied L1 block hash.
-        verify_data_commitment_storage(
+        verify_data_commitment(
             payload.blobstream_proof.storage_root,
             payload.blobstream_proof.storage_proof,
             payload.blobstream_proof.account_proof,

--- a/crates/proofs/src/blobstream_inclusion.rs
+++ b/crates/proofs/src/blobstream_inclusion.rs
@@ -9,9 +9,8 @@ use anyhow::ensure;
 use celestia_rpc::{blobstream::BlobstreamClient, Client, HeaderClient, ShareClient};
 use celestia_types::Blob;
 use hana_blobstream::blobstream::{
-    blostream_address, calculate_mapping_slot, encode_data_root_tuple,
-    verify_data_commitment_storage, BlobstreamProof, SP1Blobstream,
-    SP1BlobstreamDataCommitmentStored, DATA_COMMITMENTS_SLOT,
+    blostream_address, calculate_mapping_slot, encode_data_root_tuple, verify_data_commitment,
+    BlobstreamProof, SP1Blobstream, SP1BlobstreamDataCommitmentStored, DATA_COMMITMENTS_SLOT,
 };
 use tracing::info;
 
@@ -203,7 +202,7 @@ pub async fn get_blobstream_proof(
         .flat_map(|proof| proof.proof.into_iter().map(|bytes| bytes))
         .collect();
 
-    match verify_data_commitment_storage(
+    match verify_data_commitment(
         proof_response.storage_hash,
         proof_bytes.clone(),
         proof_response.account_proof.clone(),
@@ -217,7 +216,7 @@ pub async fn get_blobstream_proof(
         l1_head,
     ) {
         Ok(_) => {
-            println!("Succesfully verified storage proof for Blobstream data commitment");
+            println!("Succesfully verified Blobstream data commitment");
 
             return Ok(BlobstreamProof::new(
                 data_root,
@@ -235,6 +234,6 @@ pub async fn get_blobstream_proof(
                 block_header,
             ));
         }
-        Err(err) => anyhow::bail!("Error verifying storage proof {}", err),
+        Err(err) => anyhow::bail!("Error verifying data commitment {}", err),
     }
 }


### PR DESCRIPTION
Fixes storage proof verification. Key to the slot should be the hash of it. Used to be fine, but was bugged from this PR: https://github.com/celestiaorg/hana/pull/15/files#diff-de8ec76a91ac0b0a350376962c835d1266fe05ee53a190bccdf67f33da1d5516R208-R212

Used to get error like
```
2025-05-12T22:05:13.584571Z ERROR Failed to prefetch hint: Error verifying storage proof value mismatch at path Nibbles(0x0c). got: Some(0xf90211a06bb01c48312799a5b45bd869603c1c030f2ae071fd6602221087a8b73a5bcc18a082aa5dc88b86b5517e7b6549c4bfff4d6d51fab06671cf399c34f6af0c591369a0ff266cc6b40ad4fcbfab63089ee7a838422ee564187ba02fc5c01bb935dc7f47a03827609f8c847ef9b9d3faccd5dd3be7aff968afc1fcdceb95f8eb1d35beed7da02f0cf4f1e63407c8d69c78d987549323726d5f6547005b09bac8706f4fccb573a0c55219d91ab38de57222cf716fe3a8215be767b8200221aabf6970e780dbd30aa0b5201cf5ec26637b1e30eb45353c1932ad3ae4eea25310a991542315d512f386a0b98b2d579ba38dc3391c26c88f0ae0837f0470c420e7b8959a8ac4f4ec10cd5da0dc8f2505f2aa6e2076e1263a8bf24f86a27b90fbc0264d51c7d3b6bf4dc771cba08b80af7035d7b7638b0e75bfb07e99666fa6dd026d17ea24ddabda75c120d8ada0f643a4b59658f8e4a8eba19bb1c275ef3ffed2925c1dabb7dd111c21b0d8366fa08a6ba2d4ad58cc53971a1993713781b98efb020676cb9c115fa689009de1f52ca06c135f9da9dfce8282a5fa2386d33d2ed6aaf4e95fe511478ea93ef5792c04c2a056adf79690be20cf7de66941eadbbaed7dea003db2c3ddeee1e5b306a057d280a0cbc2058f1867105df13186b03425ab09698564b19e67d5333feaf3355fd88cb9a04cd417aa9d8ead010c4a356423736fbf781a8a93cb9ae25be798021580f92e8a80). expected: Some(0xa0fdcbc26524d9bf0d37251806f5650e717242852067f416c765202d306389d34e)
```