### PR TITLE
fix: fix bincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,10 +2568,10 @@ name = "hana-blobstream"
 version = "0.1.0"
 dependencies = [
  "alloy-chains",
+ "alloy-consensus",
  "alloy-contract",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth",
  "alloy-sol-types",
  "alloy-trie",
  "anyhow",

--- a/crates/blobstream/Cargo.toml
+++ b/crates/blobstream/Cargo.toml
@@ -12,7 +12,7 @@ alloy-trie.workspace = true
 alloy-contract.workspace = true
 alloy-rlp.workspace = true
 alloy-chains.workspace = true
-alloy-rpc-types-eth.workspace = true
+alloy-consensus.workspace = true
 
 anyhow.workspace = true
 bincode.workspace = true

--- a/crates/blobstream/src/blobstream.rs
+++ b/crates/blobstream/src/blobstream.rs
@@ -2,8 +2,8 @@ use std::boxed::Box;
 
 use alloc::vec::Vec;
 use alloy_chains::NamedChain;
+use alloy_consensus::Header;
 use alloy_primitives::{address, keccak256, Address, Bytes, FixedBytes, B256, U256};
-use alloy_rpc_types_eth::Header;
 use alloy_sol_types::sol;
 use alloy_trie::{proof::verify_proof, Nibbles, TrieAccount};
 use anyhow::{anyhow, Result};

--- a/crates/proofs/src/blobstream_inclusion.rs
+++ b/crates/proofs/src/blobstream_inclusion.rs
@@ -212,7 +212,7 @@ pub async fn get_blobstream_proof(
         blobstream_balance,
         blobstream_nonce,
         blobstream_code_hash,
-        block_header.clone(),
+        block_header.inner.clone(),
         l1_head,
     ) {
         Ok(_) => {
@@ -231,7 +231,7 @@ pub async fn get_blobstream_proof(
                 blobstream_balance,
                 blobstream_nonce,
                 blobstream_code_hash,
-                block_header,
+                block_header.inner.clone(),
             ));
         }
         Err(err) => anyhow::bail!("Error verifying data commitment {}", err),


### PR DESCRIPTION
Seems like `#[serde(flatten)]` is not compatible with bincode. See https://github.com/bincode-org/bincode/issues/245.

Fixes below error by using [alloy_consensus::Header](https://github.com/alloy-rs/alloy/blob/e99bc082cf4b1dd838e5cfec8b75fa7ee2f1512e/crates/consensus/src/block/header.rs#L19-L131) instead of using [alloy_rpc_types_eth::Header](https://github.com/alloy-rs/alloy/blob/e99bc082cf4b1dd838e5cfec8b75fa7ee2f1512e/crates/rpc-types-eth/src/block.rs#L304-L325).

```
Succesfully verified Blobstream data commitment
...
failed to serialize celestia oracle payload: SequenceMustHaveLength
```

Now getting
```
task 20 panicked with message "computed block hash must match host l1 head: 0x306ffff63a27e17ccc7a274809f482c912ee0c2ebe548c497d90ccdf18726425 != 0xada524f1e8805f4626e9a816df9dde7f7503acd950dabbc01435a2693bcba959"
```