### PR TITLE
fix: fix data commitment fetch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,10 +2568,10 @@ name = "hana-blobstream"
 version = "0.1.0"
 dependencies = [
  "alloy-chains",
+ "alloy-consensus",
  "alloy-contract",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth",
  "alloy-sol-types",
  "alloy-trie",
  "anyhow",

--- a/crates/blobstream/Cargo.toml
+++ b/crates/blobstream/Cargo.toml
@@ -12,7 +12,7 @@ alloy-trie.workspace = true
 alloy-contract.workspace = true
 alloy-rlp.workspace = true
 alloy-chains.workspace = true
-alloy-rpc-types-eth.workspace = true
+alloy-consensus.workspace = true
 
 anyhow.workspace = true
 bincode.workspace = true

--- a/crates/blobstream/src/blobstream.rs
+++ b/crates/blobstream/src/blobstream.rs
@@ -2,8 +2,8 @@ use std::boxed::Box;
 
 use alloc::vec::Vec;
 use alloy_chains::NamedChain;
+use alloy_consensus::Header;
 use alloy_primitives::{address, keccak256, Address, Bytes, FixedBytes, B256, U256};
-use alloy_rpc_types_eth::Header;
 use alloy_sol_types::sol;
 use alloy_trie::{proof::verify_proof, Nibbles, TrieAccount};
 use anyhow::{anyhow, Result};

--- a/crates/proofs/src/blobstream_inclusion.rs
+++ b/crates/proofs/src/blobstream_inclusion.rs
@@ -212,7 +212,7 @@ pub async fn get_blobstream_proof(
         blobstream_balance,
         blobstream_nonce,
         blobstream_code_hash,
-        block_header.clone(),
+        block_header.inner.clone(),
         l1_head,
     ) {
         Ok(_) => {
@@ -231,7 +231,7 @@ pub async fn get_blobstream_proof(
                 blobstream_balance,
                 blobstream_nonce,
                 blobstream_code_hash,
-                block_header,
+                block_header.inner.clone(),
             ));
         }
         Err(err) => anyhow::bail!("Error verifying data commitment {}", err),


### PR DESCRIPTION
## Fix bincode
Seems like #[serde(flatten)] is not compatible with bincode. See https://github.com/bincode-org/bincode/issues/245.

Fixes below error by using [alloy_consensus::Header](https://github.com/alloy-rs/alloy/blob/e99bc082cf4b1dd838e5cfec8b75fa7ee2f1512e/crates/consensus/src/block/header.rs#L19-L131) instead of using [alloy_rpc_types_eth::Header](https://github.com/alloy-rs/alloy/blob/e99bc082cf4b1dd838e5cfec8b75fa7ee2f1512e/crates/rpc-types-eth/src/block.rs#L304-L325).

```
Succesfully verified Blobstream data commitment
...
failed to serialize celestia oracle payload: SequenceMustHaveLength
```

## Fix data comimtment fetch

Fixes below storage proof verification failure error.
```
Failed to prefetch hint: Error verifying data commitment Storage proof verification failed: value mismatch at path Nibbles(0x0e0c030f0001090d040602020f0e01070a05090e07070103020600040b050403050303080906010b0001000c0f060d010700020805080b0d0508070e0b0c020b). got: None. expected: Some(0xa02ae9bb2229e21f06f6ffe636e052a930f5a554c4fd20bf5e7f90410a759d00a1)
```

Hana was fetching DA commitments past the l1 head, so storage proof was being verified against an outdated storage root.

> Hana was fetching DA commitments past the l1 head.
This should not happen. It should fail with data exhaustion error when the derivation pipeline reaches l1 head but couldn't derive the state of the target l2 block.












