### PR TITLE
chore: fix typo

### DIFF
--- a/crates/blobstream/src/blobstream.rs
+++ b/crates/blobstream/src/blobstream.rs
@@ -244,7 +244,7 @@ pub fn calculate_mapping_slot(mapping_slot: u32, key: U256) -> B256 {
 /// The canonical Blobstream address for the given chain id.
 ///
 /// Source: https://docs.celestia.org/how-to-guides/blobstream#deployed-contracts
-pub fn blostream_address(chain_id: u64) -> Option<Address> {
+pub fn blobstream_address(chain_id: u64) -> Option<Address> {
     if let Ok(chain) = NamedChain::try_from(chain_id) {
         match chain {
             NamedChain::Mainnet => Some(address!("0x7Cf3876F681Dbb6EdA8f6FfC45D66B996Df08fAe")),

--- a/crates/oracle/src/provider.rs
+++ b/crates/oracle/src/provider.rs
@@ -6,7 +6,7 @@ use alloy_primitives::{keccak256, Bytes};
 use async_trait::async_trait;
 use celestia_types::Commitment;
 use hana_blobstream::blobstream::{
-    blostream_address, encode_data_root_tuple, verify_data_commitment,
+    blobstream_address, encode_data_root_tuple, verify_data_commitment,
 };
 use hana_celestia::CelestiaProvider;
 use kona_preimage::errors::PreimageOracleError;
@@ -62,7 +62,7 @@ impl<T: CommsClient + Sync + Send> CelestiaProvider for OracleCelestiaProvider<T
         let boot = BootInfo::load(self.oracle.as_ref()).await?;
 
         // Get the expected blobstream address for the chain id.
-        let expected_blobstream_address = blostream_address(boot.rollup_config.l1_chain_id)
+        let expected_blobstream_address = blobstream_address(boot.rollup_config.l1_chain_id)
             .expect("No canonical Blobstream address found for chain id");
 
         // Verify the data commitment exists in storage on the supplied L1 block hash.

--- a/crates/proofs/src/blobstream_inclusion.rs
+++ b/crates/proofs/src/blobstream_inclusion.rs
@@ -9,7 +9,7 @@ use anyhow::ensure;
 use celestia_rpc::{blobstream::BlobstreamClient, Client, HeaderClient, ShareClient};
 use celestia_types::Blob;
 use hana_blobstream::blobstream::{
-    blostream_address, calculate_mapping_slot, encode_data_root_tuple, verify_data_commitment,
+    blobstream_address, calculate_mapping_slot, encode_data_root_tuple, verify_data_commitment,
     BlobstreamProof, SP1Blobstream, SP1BlobstreamDataCommitmentStored, DATA_COMMITMENTS_SLOT,
 };
 use tracing::info;
@@ -116,7 +116,7 @@ pub async fn get_blobstream_proof(
     let chain_id = l1_provider.get_chain_id().await?;
 
     let blobstream_address =
-        blostream_address(chain_id).expect("No canonical Blobstream address found for chain id");
+        blobstream_address(chain_id).expect("No canonical Blobstream address found for chain id");
 
     // Fetch the block's data root
     let header = celestia_node.header_get_by_height(height).await?;


### PR DESCRIPTION
Fixes typo: blostream_address -> blobstream_address.