### PR TITLE
chore: pin lumina crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,8 +101,8 @@ op-revm = { version = "5.0.1", default-features = false }
 alloy-op-evm = { version = "0.10.0", default-features = false }
 
 # Celestia
-celestia-types = "0.12.0"
-celestia-rpc = "0.11.2"
+celestia-types = "=0.12.0"
+celestia-rpc = "=0.11.2"
 jsonrpsee = "0.24.9"
 
 [profile.dev]


### PR DESCRIPTION
This is to prevent errors like `two different versions of crate `celestia_types` are being used`