### PR TITLE
Fix spelling errors in blobstream_inclusion.rs

### DIFF
--- a/crates/proofs/src/blobstream_inclusion.rs
+++ b/crates/proofs/src/blobstream_inclusion.rs
@@ -162,7 +162,7 @@ pub async fn get_blobstream_proof(
 
     // validate the proof before placing it on the KV store
     match share_proof.verify(data_root) {
-        Ok(_) => info!("Celestia share proof succesfully verified!"),
+        Ok(_) => info!("Celestia share proof successfully verified!"),
         Err(err) => return Err(err.into()),
     }
 
@@ -216,7 +216,7 @@ pub async fn get_blobstream_proof(
         l1_head,
     ) {
         Ok(_) => {
-            println!("Succesfully verified Blobstream data commitment");
+            println!("Successfully verified Blobstream data commitment");
 
             return Ok(BlobstreamProof::new(
                 data_root,


### PR DESCRIPTION


## Description

This PR fixes two spelling errors in the `blobstream_inclusion.rs` file:

- **Line 165**: Corrected "succesfully" → "successfully" in Celestia share proof verification log
- **Line 219**: Corrected "Succesfully" → "Successfully" in Blobstream data commitment verification message

